### PR TITLE
Update nginx base image to ubi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,10 @@ RUN npm run build
 RUN chgrp -R 0 /app/src && \
     chmod -R g+rwX /app/src
 
-FROM nginxinc/nginx-unprivileged
+FROM registry.access.redhat.com/ubi8/nginx-118:1-69.1652296458
 ENV HOME=/usr/share/nginx/html
 
 COPY --from=builder /app/src/dist ${HOME}
-COPY nginx-default.conf ${HOME}/default.conf.tpl
 COPY run.sh ${HOME}
 
 ENV PORT 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN chgrp -R 0 /app/src && \
     chmod -R g+rwX /app/src
 
 FROM registry.access.redhat.com/ubi8/nginx-118:1-69.1652296458
-ENV HOME=/usr/share/nginx/html
+ENV HOME=/opt/app-root/src
 
 COPY --from=builder /app/src/dist ${HOME}
 COPY run.sh ${HOME}

--- a/run.sh
+++ b/run.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-cat > /usr/share/nginx/html/config.js <<EOL
-window.API_HOST = '${API_HOST}'
-window.CONTRIBUTE_HOST = '${CONTRIBUTE_HOST}'
-window.GTM_ID = '${GTM_ID}'
-window.BASE_URL = '${BASE_URL}'
-window.STREETS_TILE_LAYER_URL = '${STREETS_TILE_LAYER_URL}'
-window.MAPBOX_ACCESS_TOKEN = '${MAPBOX_ACCESS_TOKEN}'
-window.LOGO_URL = '${LOGO_URL}'
-window.AUTH0_DOMAIN = '${AUTH0_DOMAIN}'
-window.AUTH0_CLIENT_ID = '${AUTH0_CLIENT_ID}'
-window.AUTH0_AUDIENCE = '${AUTH0_AUDIENCE}'
-EOL
+# cat > /usr/share/nginx/html/config.js <<EOL
+# window.API_HOST = '${API_HOST}'
+# window.CONTRIBUTE_HOST = '${CONTRIBUTE_HOST}'
+# window.GTM_ID = '${GTM_ID}'
+# window.BASE_URL = '${BASE_URL}'
+# window.STREETS_TILE_LAYER_URL = '${STREETS_TILE_LAYER_URL}'
+# window.MAPBOX_ACCESS_TOKEN = '${MAPBOX_ACCESS_TOKEN}'
+# window.LOGO_URL = '${LOGO_URL}'
+# window.AUTH0_DOMAIN = '${AUTH0_DOMAIN}'
+# window.AUTH0_CLIENT_ID = '${AUTH0_CLIENT_ID}'
+# window.AUTH0_AUDIENCE = '${AUTH0_AUDIENCE}'
+# EOL
 
-cat default.conf.tpl | envsubst \$ADDITIONAL_CSP_HOSTS > /etc/nginx/conf.d/default.conf
+# cat default.conf.tpl | envsubst \$ADDITIONAL_CSP_HOSTS > /etc/nginx/conf.d/default.conf
 
 nginx -g "daemon off;"

--- a/run.sh
+++ b/run.sh
@@ -1,18 +1,2 @@
 #!/bin/bash
-
-# cat > /usr/share/nginx/html/config.js <<EOL
-# window.API_HOST = '${API_HOST}'
-# window.CONTRIBUTE_HOST = '${CONTRIBUTE_HOST}'
-# window.GTM_ID = '${GTM_ID}'
-# window.BASE_URL = '${BASE_URL}'
-# window.STREETS_TILE_LAYER_URL = '${STREETS_TILE_LAYER_URL}'
-# window.MAPBOX_ACCESS_TOKEN = '${MAPBOX_ACCESS_TOKEN}'
-# window.LOGO_URL = '${LOGO_URL}'
-# window.AUTH0_DOMAIN = '${AUTH0_DOMAIN}'
-# window.AUTH0_CLIENT_ID = '${AUTH0_CLIENT_ID}'
-# window.AUTH0_AUDIENCE = '${AUTH0_AUDIENCE}'
-# EOL
-
-# cat default.conf.tpl | envsubst \$ADDITIONAL_CSP_HOSTS > /etc/nginx/conf.d/default.conf
-
 nginx -g "daemon off;"


### PR DESCRIPTION
- updates base image to use `registry.access.redhat.com/ubi8/nginx-118:1-69.1652296458`
- updates static site files to be in the default configured location
- removes configuration values in favor of them being provided in a helm configmap from `configs.yaml` [here](https://github.com/UrbanOS-Public/charts/tree/master/charts/discovery-api/templates)

[ticket link](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/711)