### PR TITLE
Bug fix: redirect of urban-os logo should be absolute

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -45,7 +45,7 @@ export default class Header extends Component {
         }`}
       >
         <div className={"logo"}>
-          <a href={`${window.BASE_URL}`}>
+          <a href={`//${window.BASE_URL}`}>
             <img src={urbanosLogo}></img>
           </a>
         </div>


### PR DESCRIPTION
Base URL Configuration is a string for the host URL without protocol.

Currently, configuring the base url this way will break the urbanos logo redirect. Including "//" insures the redirect is absolute, while still respecting the protocol, https or http.