### PR TITLE
fixing vunerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,17 @@ COPY run.sh ${HOME}
 ENV PORT 8080
 EXPOSE ${PORT}
 WORKDIR ${HOME}
+
+# =========================================================
+#  START PATCH: Solve following
+#  Urllib3 1.26.5 includes a fix for CVE-2021-33503: An issue was discovered in urllib3 before 1.26.5. When provided with a URL containing many @ characters in the authority component, the authority regular expression exhibits catastrophic backtracking, causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect. https://github.com/advisories/GHSA-q2q7-5pp4-w6pg
+# =========================================================
+USER root
+COPY docker_assets/centos.repo /etc/yum.repos.d/centos.repo
+RUN yum upgrade python3-urllib3 -y
+# =========================================================
+#  END PATCH
+# =========================================================
+
 USER default
 CMD ./run.sh

--- a/docker_assets/centos.repo
+++ b/docker_assets/centos.repo
@@ -1,0 +1,5 @@
+[centos]
+name=CentOS $releasever - $basearch
+baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Fixigin issue:

Urllib3 1.26.5 includes a fix for CVE-2021-33503: An issue was discovered in urllib3 before 1.26.5. When provided with a URL containing many @ characters in the authority component, the authority regular expression exhibits catastrophic backtracking, causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect. https://github.com/advisories/GHSA-q2q7-5pp4-w6pg


