### PR TITLE
Fix permission denied port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN chgrp -R 0 /app/src && \
 FROM nginx:alpine
 COPY docker_assets/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/src/dist /usr/share/nginx/html
-USER root
 RUN apk update && apk upgrade
 EXPOSE 8080
-USER nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker_assets/nginx.conf
+++ b/docker_assets/nginx.conf
@@ -1,4 +1,3 @@
-user  nginx;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log notice;


### PR DESCRIPTION
As openshift use arbitrary user ids
we change the container to ignore the
user and run the nginx deamon with the
openshift random user