### PR TITLE
Return nginx default config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY test-helpers ./test-helpers
 COPY config ./config
 
 RUN npm ci
+RUN npm test
 RUN npm run build
 
 RUN chgrp -R 0 /app/src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@ FROM node:14.17.4-alpine AS builder
 WORKDIR /app/src
 
 # Copy only the needed files to help docker caching
-COPY .babelrc package-lock.json package.json webpack.config.js ./
+COPY .babelrc package-lock.json package.json webpack.config.js nginx-default.conf ./
 COPY src ./src
 COPY test-helpers ./test-helpers
 COPY config ./config
 
 RUN npm ci
-RUN npm test
 RUN npm run build
 
 RUN chgrp -R 0 /app/src && \
@@ -17,6 +16,7 @@ RUN chgrp -R 0 /app/src && \
 FROM nginx:alpine
 COPY docker_assets/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/src/dist /usr/share/nginx/html
+COPY --from=builder /app/src/nginx-default.conf /etc/nginx/conf.d/default.conf
 RUN apk update && apk upgrade
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -1,0 +1,33 @@
+server {
+    listen       8080;
+    server_name  localhost;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Frame-Options "DENY";
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    add_header Pragma "no-cache";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' ${ADDITIONAL_CSP_HOSTS} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' ${ADDITIONAL_CSP_HOSTS} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+    server_tokens off;
+
+    gzip on;
+    gzip_static on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_proxied  any;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
It seems that without this file, nginx was kind enough to supply its own default - which pointed us to port 80 instead of port 8080