### PR TITLE
Do not init tagmanager without gtm_id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,8 @@ import 'regenerator-runtime/runtime'
 import TagManager from 'react-gtm-module'
 window.React = React
 
-const tagManagerArgs = {
-  gtmId: window.GTM_ID
+if (window.GTM_ID) {
+  TagManager.initialize({ gtmId: window.GTM_ID });
 }
-
-TagManager.initialize(tagManagerArgs)
 
 ReactDOM.render(<App />, document.getElementById('root'))


### PR DESCRIPTION
Discovery UI was trying to reach google tag manager when a tag wasn't set

https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/921