### PR TITLE
Update API Key docs (react-disc-ui `2.1.8`)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+## Reminders
+
+- [ ] Did you bump the version in `package.json` so that releases to npm are
+      made without version conflict?
+  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discovery UI provides default branding and navigation controls around the [react-discovery-ui](https://github.com/smartcitiesdata/react_discovery_ui) component. This allows for the base components to be brand agnostic.
 
-A guide on how to use an instance of discovery_ui is available in the [smartcitiesdata wiki](https://github.com/UrbanOS-Public/smartcitiesdata/wiki/Data-Discovery-(DiscoveryUI)-User-Manual)
+A guide on how to use an instance of discovery_ui is available in the [smartcitiesdata wiki](<https://github.com/UrbanOS-Public/smartcitiesdata/wiki/Data-Discovery-(DiscoveryUI)-User-Manual>)
 
 ## How to use
 
@@ -39,6 +39,9 @@ Runtime configurations are stored in config/config.js.
   The domain that the site will be hosted on
 
 ### Start the UI Locally
+
+- Node version `v14.17.4`
+- NPM version `v9.2.0`
 
 `npm run start`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discovery_ui",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.22",
         "@fortawesome/free-brands-svg-icons": "^5.10.2",
         "@fortawesome/react-fontawesome": "^0.1.4",
-        "@smartcitiesdata/react-discovery-ui": "^2.1.7",
+        "@smartcitiesdata/react-discovery-ui": "^2.1.8",
         "immutable": "^3.8.2",
         "react": "~16.8.6",
         "react-dom": "~16.8.6",
@@ -4375,9 +4375,9 @@
       }
     },
     "node_modules/@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.7.tgz",
-      "integrity": "sha512-X/L9X6beJTvb+SNhyJRALBDp2UCmxVBo6U8+wZEz+3KecOHbe4xrjiWUTLXjiOfkfwKIo0rqKIg+n7Tvn/P3+A==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.8.tgz",
+      "integrity": "sha512-8gvw+F7aHOyn3DZQx2Nr1xTxZcw1wZUZaK3U7UPCxlDxlZ+aM24Aw83S/9POd/iBlr/ovhufTfDTcS2z/xyEhw==",
       "dependencies": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.10.3",
@@ -35719,9 +35719,9 @@
       }
     },
     "@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.7.tgz",
-      "integrity": "sha512-X/L9X6beJTvb+SNhyJRALBDp2UCmxVBo6U8+wZEz+3KecOHbe4xrjiWUTLXjiOfkfwKIo0rqKIg+n7Tvn/P3+A==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.8.tgz",
+      "integrity": "sha512-8gvw+F7aHOyn3DZQx2Nr1xTxZcw1wZUZaK3U7UPCxlDxlZ+aM24Aw83S/9POd/iBlr/ovhufTfDTcS2z/xyEhw==",
       "requires": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@smartcitiesdata/react-discovery-ui": "^2.1.7",
+    "@smartcitiesdata/react-discovery-ui": "^2.1.8",
     "immutable": "^3.8.2",
     "react": "~16.8.6",
     "react-dom": "~16.8.6",


### PR DESCRIPTION
## Description

https://github.com/UrbanOS-Public/react_discovery_ui/pull/294

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
