### PR TITLE
Utilize react-disc-ui v 2.1.11

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 
 - [ ] Did you bump the version in `package.json` so that releases to npm are
       made without version conflict?
-  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?
+  - [ ] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?

--- a/package-lock.json
+++ b/package-lock.json
@@ -3419,9 +3419,9 @@
       }
     },
     "@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.10.tgz",
-      "integrity": "sha512-Q1PBqQFQ6/9Mxj/P7hn/6axoWpmBQHrsVBedXx1weQTssFD8/NwLPnBVclINU/0aPkUjz37iJoySO1g/wviWvg==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.11.tgz",
+      "integrity": "sha512-f3sU3QCcM4tHX3yWdL32LISpKuf7pP6sHRG15V7ucDwnK8+V7Pie94aHRCOXNV/dRdehXPppK0qGjV1MRVBr4A==",
       "requires": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.10.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@smartcitiesdata/react-discovery-ui": "2.1.10",
+    "@smartcitiesdata/react-discovery-ui": "2.1.11",
     "immutable": "^3.8.2",
     "react": "~16.8.6",
     "react-dom": "~16.8.6",


### PR DESCRIPTION
## Description

https://github.com/UrbanOS-Public/react_discovery_ui/pull/299

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?
