### PR TITLE
Change dev port from 9001 to 9002

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,7 @@ module.exports = (env, argv) => {
       contentBase: path.join(__dirname, 'dist'),
       compress: productionOptimizationsEnabled,
       open: true,
-      port: 9001,
+      port: 9002,
       host: 'localhost'
     },
     plugins: plugins,


### PR DESCRIPTION
## Description

Change the default local dev port to 9002, so that it doesn't conflict with locally running minio pods on 9001 and 9002

9002 is now an allowed port for UrbanOS tenants by default, so this change will no longer break auth flow.
https://github.com/UrbanOS-Public/charts/blob/master/charts/urban-os/templates/auth0-config.yaml#L13

## Reminders

This doesn't change any published code, no package changes needed