### PR TITLE
Update default csps to include openstreetmap in addition to mapbox

### DIFF
--- a/nginx-csps.conf
+++ b/nginx-csps.conf
@@ -1,4 +1,4 @@
-# These serve as defaults for deployments without helm or local development.
-# This is overriden by the configs.yaml template in charts/discovery_ui. 
+# These serve as the default for non helm deployments of this image.
+# These are overriden by the configs.yaml template in charts/discovery_ui. 
 # Changes here will likely need to be made there as well.
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.auth0.com *.mapbox.com *.plot.ly http://localhost:*; worker-src blob:;";
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' *.amazonaws.com *.mapbox.com *.openstreetmap.org *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.auth0.com *.mapbox.com *.openstreetmap.org *.plot.ly http://localhost:*; worker-src blob:;";


### PR DESCRIPTION
## Description

- Adds openstreepmap.org to the default allowed CSPs

## Reminders

(This file is only used for local dev of the container, no package alterations made)

- [ ] ~~Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?~~
  - [ ] ~~Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?~~
