### PR TITLE
Fix discovery UI format for smaller screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,8 @@ body {
   min-height: 100%;
   margin: 0;
   width: 100%;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+
 }

--- a/src/index.css
+++ b/src/index.css
@@ -26,5 +26,4 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
-
 }


### PR DESCRIPTION
## Description

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?
