### PR TITLE
Installed react-discovery 2.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2647,9 +2647,9 @@
       }
     },
     "@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.18.tgz",
-      "integrity": "sha512-unOkQXesgYTh7qDUxo1cttEdol28bmS+ZEhb2IKtlkyIhik2iG3wBMfeXOSFsNAfkbiOR8qB2zNUZYSsT8I1wA==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.20.tgz",
+      "integrity": "sha512-s6EeAcmmdF7rPHEaFVF+9rKldaIuFLCDNkhRuvj3/hC3YtIKAdPYDEVukQSXEfeUePib2HfSMJ6GXGnTFKg8hw==",
       "requires": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.20.13",
@@ -3133,9 +3133,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.30",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.30.tgz",
-      "integrity": "sha512-AnME2cHDH11Pxt/yYX6r0w448BfTwQOLEhQEjCdwB7QskEI7EKtxhGUsExTQe/MsY3D9D5rMtu62WRocw9A8FA==",
+      "version": "18.0.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.31.tgz",
+      "integrity": "sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.20",
+  "version": "2.1.21",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@smartcitiesdata/react-discovery-ui": "2.1.18",
+    "@smartcitiesdata/react-discovery-ui": "2.1.20",
     "buffer": "^6.0.3",
     "definitions": "0.0.2",
     "immutable": "^3.8.2",


### PR DESCRIPTION
## Description

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?
