### PR TITLE
Bump react-discovery-ui version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2647,9 +2647,9 @@
       }
     },
     "@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.20.tgz",
-      "integrity": "sha512-s6EeAcmmdF7rPHEaFVF+9rKldaIuFLCDNkhRuvj3/hC3YtIKAdPYDEVukQSXEfeUePib2HfSMJ6GXGnTFKg8hw==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.21.tgz",
+      "integrity": "sha512-JtbLK/JKPlZST/Qi05K99lCXJJMpBcre6DSxS3ASP/vENAraoPbOq+BL0MYujK6e8mkotMyNALlG36gYyHIPJw==",
       "requires": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.20.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@smartcitiesdata/react-discovery-ui": "2.1.20",
+    "@smartcitiesdata/react-discovery-ui": "2.1.21",
     "buffer": "^6.0.3",
     "definitions": "0.0.2",
     "immutable": "^3.8.2",


### PR DESCRIPTION
## Description

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?
