### PR TITLE
update react-discovery-ui to 2.1.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2647,9 +2647,9 @@
       }
     },
     "@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.22.tgz",
-      "integrity": "sha512-rGD+RajGzy4oHdNk5SAbRQTQc57/G7rgt/13nxyefSMET/ozOof2EkWKHCm/QbLNJLU1aNmosfqJH48zrc81SA==",
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.23.tgz",
+      "integrity": "sha512-jEFIMOwa2xLq/xRKQ0bo900RKGPRwY42wsZleW3OFFbrqfXL83mZVjvqlAQl4dcszOWUj5RowzNGi1nCplcxHw==",
       "requires": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.20.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@smartcitiesdata/react-discovery-ui": "2.1.22",
+    "@smartcitiesdata/react-discovery-ui": "2.1.23",
     "buffer": "^6.0.3",
     "definitions": "0.0.2",
     "immutable": "^3.8.2",


### PR DESCRIPTION
## Description

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?
