### PR TITLE
Make discovery ui same version as react discovery ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.33",
+  "version": "2.1.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.33",
+  "version": "2.1.37",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {


### PR DESCRIPTION
## Description

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` with npm@6.14.14 to update the version number in the `package.lock`?
