### PR TITLE
bump version to enable new image build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/react-fontawesome": "^0.1.4",
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
-        "@smartcitiesdata/react-discovery-ui": "2.1.41",
+        "@smartcitiesdata/react-discovery-ui": "2.1.42",
         "buffer": "^6.0.3",
         "definitions": "0.0.2",
         "immutable": "^3.8.2",
@@ -3922,9 +3922,9 @@
       }
     },
     "node_modules/@smartcitiesdata/react-discovery-ui": {
-      "version": "2.1.41",
-      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.41.tgz",
-      "integrity": "sha512-6pR3pKEnGwhgVFDG/jcVGAD+gsGF2g1nA0T179MxbdNY8y+QSlWS2vTFMvL1akLUO+tbPgaSl9ZRLRlovfp3dQ==",
+      "version": "2.1.42",
+      "resolved": "https://registry.npmjs.org/@smartcitiesdata/react-discovery-ui/-/react-discovery-ui-2.1.42.tgz",
+      "integrity": "sha512-+pxA+M5yL/o6TZCPZ1GjpdZp9xw6a/YUKOKjqLjCgGXdKmYFF6WF7yDP+pMRtPLkV+YfswNlIIOVbihZxPoskg==",
       "dependencies": {
         "@auth0/auth0-spa-js": "1.22.5",
         "@babel/runtime": "^7.20.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.45",
+  "version": "2.1.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discovery_ui",
-      "version": "2.1.45",
+      "version": "2.1.46",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.45",
+  "version": "2.1.46",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-brands-svg-icons": "^5.10.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@smartcitiesdata/react-discovery-ui": "2.1.41",
+    "@smartcitiesdata/react-discovery-ui": "2.1.42",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "buffer": "^6.0.3",


### PR DESCRIPTION
## Description

Bump version to trigger new docker image build with security updates

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` with npm@20.12.0 to update the version number in the `package.lock`?
