### PR TITLE
version bump to enable fresh image build with latest versions of libr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discovery_ui",
-      "version": "2.1.46",
+      "version": "2.1.47",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {


### PR DESCRIPTION
…aries

## Description

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` with npm@20.12.0 to update the version number in the `package.lock`?
