### PR TITLE
bump version to trigger image rebuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.47",
+  "version": "2.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discovery_ui",
-      "version": "2.1.47",
+      "version": "2.1.48",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery_ui",
-  "version": "2.1.47",
+  "version": "2.1.48",
   "description": "UI for dataset discovery",
   "main": "./src/index.js",
   "repository": {


### PR DESCRIPTION
## Description

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` with npm@20.12.0 to update the version number in the `package.lock`?
